### PR TITLE
feat(auth): Implement user login and token generation

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1387,6 +1387,24 @@ files = [
 windows-terminal = ["colorama (>=0.4.6)"]
 
 [[package]]
+name = "pyjwt"
+version = "2.10.1"
+description = "JSON Web Token implementation in Python"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "PyJWT-2.10.1-py3-none-any.whl", hash = "sha256:dcdd193e30abefd5debf142f9adfcdd2b58004e644f25406ffaebd50bd98dacb"},
+    {file = "pyjwt-2.10.1.tar.gz", hash = "sha256:3cc5772eb20009233caf06e9d8a0577824723b44e6648ee0a2aedb6cf9381953"},
+]
+
+[package.extras]
+crypto = ["cryptography (>=3.4.0)"]
+dev = ["coverage[toml] (==5.0.4)", "cryptography (>=3.4.0)", "pre-commit", "pytest (>=6.0.0,<7.0.0)", "sphinx", "sphinx-rtd-theme", "zope.interface"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["coverage[toml] (==5.0.4)", "pytest (>=6.0.0,<7.0.0)"]
+
+[[package]]
 name = "pytest"
 version = "8.4.1"
 description = "pytest: simple powerful testing with Python"
@@ -2313,4 +2331,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11"
-content-hash = "4c52d018d2178a1653757cdb6038bd80c40a9df05e35e4a1dab6f3c50a0f11f4"
+content-hash = "6939975c3dc0d9b462103ef75931bd20d7d317810687c487134ef69252acbf85"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,8 @@ dependencies = [
     "alembic (>=1.16.4,<2.0.0)",
     "dependency-injector (>=4.48.1,<5.0.0)",
     "phonenumbers (>=9.0.12,<10.0.0)",
-    "bcrypt (>=4.3.0,<5.0.0)"
+    "bcrypt (>=4.3.0,<5.0.0)",
+    "pyjwt (>=2.10.1,<3.0.0)"
 ]
 
 

--- a/src/api/users/user_dto.py
+++ b/src/api/users/user_dto.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Union, Optional
 
 from pydantic import BaseModel, Field, EmailStr, model_validator
@@ -42,3 +43,19 @@ class BusinessUserDTO(BaseModel):
 
 class UserAuthDTO(BaseModel):
     password: str
+
+
+class LoginUserDTO(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class TokenDataDTO(BaseModel):
+    token_str: str
+    expires_at: datetime
+
+
+class LoginResponseDTO(BaseModel):
+    access_token: str
+    refresh_token: str
+    token_type: str = "Bearer"

--- a/src/api/users/user_routers.py
+++ b/src/api/users/user_routers.py
@@ -3,9 +3,9 @@ from typing import Annotated
 from dependency_injector.wiring import inject, Provide
 from fastapi import APIRouter, Depends
 
-from src.api.users.user_dto import UserDTO
+from src.api.users.user_dto import UserDTO, LoginUserDTO, LoginResponseDTO
 from src.configuration.dependencies.depends import DependencyContainer
-from src.core.users.application.usecases import RegisterUserUseCase
+from src.core.users.application.usecases import RegisterUserUseCase, LoginUserUseCase
 
 users_router = APIRouter(prefix="/api/v1", tags=["Users"])
 
@@ -21,3 +21,15 @@ async def register_user(
 ):
     await register_usecase.execute(user_dto=user_data)
     return {"message": "success"}
+
+
+@users_router.post("/auth/login", response_model=LoginResponseDTO)
+@inject
+async def login_user(
+    user_data: LoginUserDTO,
+    login_usecase: Annotated[
+        LoginUserUseCase,
+        Depends(Provide[DependencyContainer.login_usecase])
+    ]
+):
+    return await login_usecase.execute(user_data)

--- a/src/configuration/conf/settings.py
+++ b/src/configuration/conf/settings.py
@@ -9,9 +9,16 @@ class DatabaseConnectionSettings(BaseSettings):
     POSTGRES_USER: str
     POSTGRES_PASS: str
 
+    SECRET_KEY: str
+    ALGORITHM: str
+    ACCESS_TOKEN_LIFETIME: int
+    REFRESH_TOKEN_LIFETIME: int
+    EMAIL_TOKEN_LIFETIME: int
+
     @computed_field(return_type=str)
     @property
     def database_url(self):
         return f"postgresql+asyncpg://{self.POSTGRES_USER}:{self.POSTGRES_PASS}@{self.POSTGRES_HOST}:{self.POSTGRES_PORT}/{self.POSTGRES_NAME}"
 
     model_config = SettingsConfigDict(env_file=".env")
+

--- a/src/configuration/database/migrations/versions/e6d820839b0e_initial_user_models.py
+++ b/src/configuration/database/migrations/versions/e6d820839b0e_initial_user_models.py
@@ -1,8 +1,8 @@
-"""init_user_models
+"""initial_user_models
 
-Revision ID: 0c4d9cdfe66c
+Revision ID: e6d820839b0e
 Revises: 
-Create Date: 2025-08-28 01:59:46.247457
+Create Date: 2025-09-05 15:54:54.554670
 
 """
 from typing import Sequence, Union
@@ -12,7 +12,7 @@ import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.
-revision: str = '0c4d9cdfe66c'
+revision: str = 'e6d820839b0e'
 down_revision: Union[str, Sequence[str], None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -37,7 +37,7 @@ def upgrade() -> None:
     )
     op.create_table('auth_tokens',
     sa.Column('user_id', sa.UUID(), nullable=False),
-    sa.Column('token_type', sa.Enum('REFRESH_TOKEN', 'EMAIL_TOKEN', 'PASSWORD_RESET_TOKEN', name='tokentypes'), nullable=False),
+    sa.Column('token_type', sa.Enum('REFRESH_TOKEN', 'ACCESS_TOKEN', 'EMAIL_CONFIRMATION_TOKEN', name='tokentypeenum'), nullable=False),
     sa.Column('token_value', sa.Text(), nullable=False),
     sa.Column('is_revoked', sa.Boolean(), nullable=False),
     sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),

--- a/src/configuration/database/models/users.py
+++ b/src/configuration/database/models/users.py
@@ -5,7 +5,7 @@ from datetime import datetime
 from sqlalchemy import UUID, String, DateTime, func, ForeignKey, Enum, Boolean, Text
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
-from src.core.users.domain.enums import UserRoleEnum, BusinessTypeEnum
+from src.core.users.domain.enums import UserRoleEnum, BusinessTypeEnum, TokenTypeEnum
 from src.configuration.database.connection import Base
 
 
@@ -73,13 +73,8 @@ class UserAuth(BaseModel):
 class AuthToken(BaseModel):
     __tablename__ = "auth_tokens"
 
-    class TokenTypes(enum.Enum):
-        REFRESH_TOKEN = "refresh_token"
-        EMAIL_TOKEN = "email_token"
-        PASSWORD_RESET_TOKEN = "password_reset_token"
-
     user_id: Mapped[uuid.UUID] = mapped_column(ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
-    token_type: Mapped[TokenTypes] = mapped_column(Enum(TokenTypes), nullable=False)
+    token_type: Mapped[TokenTypeEnum] = mapped_column(Enum(TokenTypeEnum), nullable=False)
     token_value: Mapped[str] = mapped_column(Text, nullable=False, unique=True)
     is_revoked: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
     user: Mapped["User"] = relationship(back_populates="tokens")

--- a/src/configuration/dependencies/depends.py
+++ b/src/configuration/dependencies/depends.py
@@ -1,4 +1,5 @@
 import uuid
+from datetime import timedelta
 
 from dependency_injector import containers, providers
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
@@ -6,9 +7,10 @@ from sqlalchemy.orm import sessionmaker
 
 from src.configuration.conf.settings import DatabaseConnectionSettings
 from src.configuration.database.connection import get_async_session
-from src.core.users.application.usecases import RegisterUserUseCase
+from src.core.users.application.usecases import RegisterUserUseCase, LoginUserUseCase
 from src.core.users.infrastructure.services.password_hasher import BcryptPasswordHasher
-from src.core.users.infrastructure.user_repository import UserRepository
+from src.core.users.infrastructure.services.pyjwt_token import PyJWTTokenService
+from src.core.users.infrastructure.user_repository import UserRepository, AuthTokenRepository
 
 
 class DependencyContainer(containers.DeclarativeContainer):
@@ -51,4 +53,33 @@ class DependencyContainer(containers.DeclarativeContainer):
         hasher=password_hasher
     )
 
+    token_service = providers.Singleton(
+        PyJWTTokenService,
+        secret_key=config.SECRET_KEY,
+        algorithm=config.ALGORITHM,
 
+        access_token_lifetime=providers.Factory(
+            timedelta,
+            minutes=config.ACCESS_TOKEN_LIFETIME.as_int()
+        ),
+        refresh_token_lifetime=providers.Factory(
+            timedelta,
+            days=config.REFRESH_TOKEN_LIFETIME.as_int()
+        ),
+        email_token_lifetime=providers.Factory(
+            timedelta,
+            hours=config.EMAIL_TOKEN_LIFETIME.as_int()
+        )
+    )
+
+    token_repository = providers.Factory(
+        AuthTokenRepository,
+        session=async_session
+    )
+
+    login_usecase = providers.Factory(
+        LoginUserUseCase,
+        user_repo=user_repository,
+        token_service=token_service,
+        token_repository=token_repository
+    )

--- a/src/core/users/application/usecases.py
+++ b/src/core/users/application/usecases.py
@@ -1,7 +1,14 @@
-from src.api.users.user_dto import UserDTO, IndividualUserDTO, BusinessUserDTO, UserAuthDTO
-from src.core.users.infrastructure.factories import UserFactory
+import uuid
+from typing import Tuple
+
+from src.api.users.user_dto import UserDTO, IndividualUserDTO, BusinessUserDTO, UserAuthDTO, LoginUserDTO, \
+    LoginResponseDTO, TokenDataDTO
+from src.core.users.domain.entities import UserAggregate
+from src.core.users.infrastructure.factories import UserFactory, AuthTokenFactory
 from src.core.users.domain.interfaces import AbstractRepository
 from src.core.users.infrastructure.services.password_hasher import BcryptPasswordHasher
+from src.core.users.infrastructure.services.pyjwt_token import PyJWTTokenService
+from src.core.users.infrastructure.user_repository import AuthTokenRepository
 
 
 class RegisterUserUseCase:
@@ -12,4 +19,56 @@ class RegisterUserUseCase:
     async def execute(self, user_dto: UserDTO):
         user_aggregate = UserFactory.create(user_dto)
         await self.user_repo.save(user_aggregate)
+
+
+class LoginUserUseCase:
+    def __init__(
+        self,
+        user_repo: AbstractRepository,
+        token_service: PyJWTTokenService,
+        token_repository: AuthTokenRepository
+    ):
+        self.user_repo = user_repo
+        self.token_service = token_service
+        self.token_repository = token_repository
+
+    async def execute(self, login_data: LoginUserDTO):
+        """Этот метод я разнес по нескольким приватным методам"""
+        user = await self._get_validated_user(login_data)
+        access_token, refresh_token = self._create_token_pair(user)
+        await self._persist_refresh_token(user.id, refresh_token)
+        return self._build_response(access_token, refresh_token)
+
+    async def _get_validated_user(self, login_data: LoginUserDTO):
+        user = await self.user_repo.get_by_email(login_data.email)
+        if not user:
+            raise ValueError("Пользователя с таким email не существует!")
+
+        password = user.authentication.password
+        is_match = password.matches(login_data.password)
+
+        if not is_match:
+            raise ValueError("Неправильный пароль!")
+
+        return user
+
+    def _create_token_pair(self, user: UserAggregate) -> Tuple[TokenDataDTO, TokenDataDTO]:
+        access_token = self.token_service.create_access_token(user.id)
+        refresh_token = self.token_service.create_refresh_token(user.id)
+        return access_token, refresh_token
+
+    async def _persist_refresh_token(self, user_id: uuid.UUID, refresh_token: TokenDataDTO):
+        refresh_token_aggregate = AuthTokenFactory.create_refresh_token(
+            user_id=user_id,
+            token_value=refresh_token.token_str,
+            expires_at=refresh_token.expires_at
+        )
+        await self.token_repository.save(refresh_token_aggregate)
+
+    def _build_response(self, access_token: TokenDataDTO, refresh_token: TokenDataDTO) -> LoginResponseDTO:
+        return LoginResponseDTO(
+            access_token=access_token.token_str,
+            refresh_token=refresh_token.token_str
+        )
+
 

--- a/src/core/users/domain/entities.py
+++ b/src/core/users/domain/entities.py
@@ -1,8 +1,9 @@
 import uuid
 from dataclasses import dataclass
+from datetime import datetime
 from typing import Union
 
-from src.core.users.domain.enums import UserRoleEnum, BusinessTypeEnum
+from src.core.users.domain.enums import UserRoleEnum, BusinessTypeEnum, TokenTypeEnum
 from src.core.users.domain.value_objects import Fullname, Email, Phone, OrganizationFullname, IIN, BIN, Password
 
 
@@ -33,3 +34,13 @@ class BusinessUserEntity:
 @dataclass
 class UserAuthEntity:
     password: Password
+
+
+@dataclass
+class AuthTokenAggregate:
+    id: uuid.UUID
+    user_id: uuid.UUID
+    token_type: TokenTypeEnum
+    token_value: str
+    is_revoked: bool
+    expires_at: datetime

--- a/src/core/users/domain/enums.py
+++ b/src/core/users/domain/enums.py
@@ -10,3 +10,8 @@ class BusinessTypeEnum(enum.Enum):
     IP = "ip"
     TOO = "too"
 
+
+class TokenTypeEnum(enum.Enum):
+    REFRESH_TOKEN = "refresh_token"
+    ACCESS_TOKEN = "access_token"
+    EMAIL_CONFIRMATION_TOKEN = "email_confirmation_token"

--- a/src/core/users/domain/value_objects.py
+++ b/src/core/users/domain/value_objects.py
@@ -93,3 +93,6 @@ class Password:
         hashed_str = BcryptPasswordHasher.hash_password(raw_password)
         return cls(hashed_str)
 
+    def matches(self, raw_password: str) -> bool:
+        verify = BcryptPasswordHasher.verify_password(raw_password, self.hashed_password)
+        return verify

--- a/src/core/users/infrastructure/factories.py
+++ b/src/core/users/infrastructure/factories.py
@@ -1,15 +1,17 @@
 import uuid
+from datetime import datetime
 
 from src.api.users.user_dto import UserDTO, IndividualUserDTO, BusinessUserDTO, UserAuthDTO
-from src.core.users.domain.entities import IndividualUserEntity, BusinessUserEntity, UserAggregate, UserAuthEntity
-from src.core.users.domain.enums import UserRoleEnum
+from src.core.users.domain.entities import IndividualUserEntity, BusinessUserEntity, UserAggregate, UserAuthEntity, \
+    AuthTokenAggregate
+from src.core.users.domain.enums import UserRoleEnum, TokenTypeEnum
 from src.core.users.domain.value_objects import Fullname, Email, Phone, OrganizationFullname, IIN, BIN, Password
 
 
 class UserFactory:
     @staticmethod
     def create(user_dto: UserDTO):
-        profile = UserFactory._create_profile(user_dto.role, user_dto.profile)
+        profile = UserProfileFactory.create(user_dto)
         authentication = UserAuthFactory.create(user_dto.authentication)
 
         return UserAggregate(
@@ -22,15 +24,17 @@ class UserFactory:
             authentication=authentication
         )
 
+
+class UserProfileFactory:
     @staticmethod
-    def _create_profile(role: UserRoleEnum, profile_dto):
-        match role:
-            case UserRoleEnum.INDIVIDUAL:
-                return IndividualUserFactory.create(profile_dto)
-            case UserRoleEnum.BUSINESS:
-                return BusinessUserFactory.create(profile_dto)
-            case _:
-                raise ValueError(f"Unsupported aggregate role: {role}")
+    def create(user_dto: UserDTO):
+        if user_dto.role == UserRoleEnum.INDIVIDUAL:
+            return IndividualUserFactory.create(user_dto.profile)
+
+        if user_dto.role == UserRoleEnum.BUSINESS:
+            return BusinessUserFactory.create(user_dto.profile)
+
+        raise ValueError("Unsupported profile type...")
 
 
 class IndividualUserFactory:
@@ -55,4 +59,48 @@ class UserAuthFactory:
     def create(auth_dto: UserAuthDTO):
         return UserAuthEntity(
             password=Password.from_raw(auth_dto.password)
+        )
+
+
+class AuthTokenFactory:
+    @staticmethod
+    def create_refresh_token(
+        user_id: uuid.UUID,
+        token_value: str,
+        expires_at: datetime
+    ):
+        return AuthTokenFactory._create(
+            user_id=user_id,
+            token_type=TokenTypeEnum.REFRESH_TOKEN,
+            token_value=token_value,
+            expires_at=expires_at
+        )
+
+    @staticmethod
+    def create_email_token(
+        user_id: uuid.UUID,
+        token_value: str,
+        expires_at: datetime
+    ):
+        return AuthTokenFactory._create(
+            user_id=user_id,
+            token_type=TokenTypeEnum.EMAIL_CONFIRMATION_TOKEN,
+            token_value=token_value,
+            expires_at=expires_at
+        )
+
+    @staticmethod
+    def _create(
+        user_id: uuid.UUID,
+        token_type: TokenTypeEnum,
+        token_value: str,
+        expires_at: datetime
+    ):
+        return AuthTokenAggregate(
+            id=uuid.uuid4(),
+            user_id=user_id,
+            token_type=token_type,
+            token_value=token_value,
+            is_revoked=False,
+            expires_at=expires_at
         )

--- a/src/core/users/infrastructure/mappers.py
+++ b/src/core/users/infrastructure/mappers.py
@@ -1,12 +1,16 @@
-from src.core.users.domain.entities import UserAggregate, UserAuthEntity
+from typing import Union
+
+from src.core.users.domain.entities import UserAggregate, UserAuthEntity, IndividualUserEntity, BusinessUserEntity, \
+    AuthTokenAggregate
 from src.core.users.domain.enums import UserRoleEnum
-from src.configuration.database.models.users import User, IndividualProfile, BusinessProfile, UserAuth
+from src.configuration.database.models.users import User, IndividualProfile, BusinessProfile, UserAuth, AuthToken
+from src.core.users.domain.value_objects import Fullname, Email, Phone, OrganizationFullname, IIN, BIN, Password
 
 
-class UserORMMapper:
+class UserMapper:
     @staticmethod
     def to_orm(user_aggregate: UserAggregate) -> User:
-        user_orm = User(
+        user_model = User(
             id=user_aggregate.id,
             role=user_aggregate.role,
             first_name=user_aggregate.fullname.first_name,
@@ -16,39 +20,76 @@ class UserORMMapper:
             phone=user_aggregate.phone.phone,
         )
 
-        profile_orm = UserORMMapper._attach_profile(user_aggregate)
-        user_orm.auth = UserAuthMapper.to_orm(user_aggregate)
+        profile_model = UserProfileMapper.to_orm(user_aggregate)
+        user_model.auth = UserAuthMapper.to_orm(user_aggregate)
 
-        match profile_orm:
+        match profile_model:
             case IndividualProfile():
-                user_orm.individual_profile = profile_orm
+                user_model.individual_profile = profile_model
             case BusinessProfile():
-                user_orm.business_profile = profile_orm
+                user_model.business_profile = profile_model
             case _:
-                raise ValueError(f"Unsupported profile type: {type(profile_orm)}")
+                raise ValueError(f"Unsupported profile type: {type(profile_model)}")
 
-        return user_orm
+        return user_model
 
     @staticmethod
-    def _attach_profile(user_aggregate: UserAggregate):
-        match user_aggregate.role:
-            case UserRoleEnum.INDIVIDUAL:
-                return IndividualUserORMMapper.to_orm(user_aggregate)
-            case UserRoleEnum.BUSINESS:
-                return BusinessUserORMMapper.to_orm(user_aggregate)
-            case _:
-                raise ValueError(f"Unsupported role type: {user_aggregate.role}")
+    def to_domain(user_model: User):
+        profile = UserProfileMapper.to_domain(user_model)
+        authentication = UserAuthMapper.to_domain(user_model.auth)
+
+        return UserAggregate(
+            id=user_model.id,
+            role=user_model.role,
+            fullname=Fullname(
+                first_name=user_model.first_name,
+                last_name=user_model.last_name,
+                patronymic=user_model.patronymic
+            ),
+            email=Email(user_model.email),
+            phone=Phone.from_raw(user_model.phone),
+            profile=profile,
+            authentication=authentication
+        )
 
 
-class IndividualUserORMMapper:
+class UserProfileMapper:
+    @staticmethod
+    def to_orm(user_aggregate: UserAggregate) -> Union[IndividualProfile, BusinessProfile]:
+        if user_aggregate.role == UserRoleEnum.INDIVIDUAL:
+            return IndividualUserMapper.to_orm(user_aggregate)
+
+        if user_aggregate.role == UserRoleEnum.BUSINESS:
+            return BusinessUserMapper.to_orm(user_aggregate)
+
+        raise ValueError("Unsupported profile type ...")
+
+    @staticmethod
+    def to_domain(user_model: User) -> Union[IndividualUserEntity, BusinessUserEntity]:
+        if user_model.individual_profile:
+            return IndividualUserMapper.to_domain(user_model.individual_profile)
+
+        if user_model.business_profile:
+            return BusinessUserMapper.to_domain(user_model.business_profile)
+
+        raise ValueError("Unsupported profile type ...")
+
+
+class IndividualUserMapper:
     @staticmethod
     def to_orm(user_aggregate: UserAggregate) -> IndividualProfile:
         return IndividualProfile(
             user_id=user_aggregate.id
         )
 
+    @staticmethod
+    def to_domain(individual_model: IndividualProfile) -> IndividualUserEntity:
+        return IndividualUserEntity(
 
-class BusinessUserORMMapper:
+        )
+
+
+class BusinessUserMapper:
     @staticmethod
     def to_orm(user_aggregate: UserAggregate) -> BusinessProfile:
         return BusinessProfile(
@@ -59,6 +100,15 @@ class BusinessUserORMMapper:
             bin=user_aggregate.profile.bin.bin
         )
 
+    @staticmethod
+    def to_domain(business_model: BusinessProfile) -> BusinessUserEntity:
+        return BusinessUserEntity(
+            business_type=business_model.business_type,
+            organization_fullname=OrganizationFullname(business_model.organization_fullname),
+            iin=IIN(business_model.iin),
+            bin=BIN(business_model.bin)
+        )
+
 
 class UserAuthMapper:
     @staticmethod
@@ -66,4 +116,34 @@ class UserAuthMapper:
         return UserAuth(
             user_id=user_aggregate.id,
             hashed_password=user_aggregate.authentication.password.hashed_password
+        )
+
+    @staticmethod
+    def to_domain(auth_model: UserAuth) -> UserAuthEntity:
+        return UserAuthEntity(
+            password=Password(auth_model.hashed_password)
+        )
+
+
+class AuthTokenMapper:
+    @staticmethod
+    def to_orm(token_aggregate: AuthTokenAggregate) -> AuthToken:
+        return AuthToken(
+            id=token_aggregate.id,
+            user_id=token_aggregate.user_id,
+            token_type=token_aggregate.token_type,
+            token_value=token_aggregate.token_value,
+            is_revoked=token_aggregate.is_revoked,
+            expires_at=token_aggregate.expires_at
+        )
+
+    @staticmethod
+    def to_domain(token_model: AuthToken) -> AuthTokenAggregate:
+        return AuthTokenAggregate(
+            id=token_model.id,
+            user_id=token_model.user_id,
+            token_type=token_model.token_type,
+            token_value=token_model.token_value,
+            is_revoked=token_model.is_revoked,
+            expires_at=token_model.expires_at
         )

--- a/src/core/users/infrastructure/services/password_hasher.py
+++ b/src/core/users/infrastructure/services/password_hasher.py
@@ -8,4 +8,6 @@ class BcryptPasswordHasher:
         hashed = bcrypt.hashpw(password_str.encode("utf-8"), bcrypt.gensalt())
         return hashed.decode("utf-8")
 
-
+    @staticmethod
+    def verify_password(password: str, hashed: str):
+        return bcrypt.checkpw(password.encode("utf-8"), hashed.encode("utf-8"))

--- a/src/core/users/infrastructure/services/pyjwt_token.py
+++ b/src/core/users/infrastructure/services/pyjwt_token.py
@@ -1,0 +1,52 @@
+import uuid
+from datetime import timedelta, datetime, timezone
+
+import jwt
+
+from src.api.users.user_dto import TokenDataDTO
+from src.core.users.domain.enums import TokenTypeEnum
+
+
+class PyJWTTokenService:
+    def __init__(
+        self,
+        secret_key: str,
+        algorithm: str,
+        access_token_lifetime: timedelta,
+        refresh_token_lifetime: timedelta,
+        email_token_lifetime: timedelta
+    ):
+        self._secret_key = secret_key
+        self._algorithm = algorithm
+        self._access_token_lifetime = access_token_lifetime
+        self._refresh_token_lifetime = refresh_token_lifetime
+        self._email_token_lifetime = email_token_lifetime
+
+    def create_refresh_token(self, user_id: uuid.UUID) -> TokenDataDTO:
+        expires_at = datetime.now(timezone.utc) + self._refresh_token_lifetime
+        payload = {"sub": str(user_id), "exp": expires_at, "token_type": TokenTypeEnum.REFRESH_TOKEN.value}
+        token_str = jwt.encode(payload=payload, key=self._secret_key, algorithm=self._algorithm)
+        return TokenDataDTO(token_str=token_str, expires_at=expires_at)
+
+    def create_access_token(self, user_id: uuid.UUID) -> TokenDataDTO:
+        expires_at = datetime.now(timezone.utc) + self._access_token_lifetime
+        payload = {"sub": str(user_id), "exp": expires_at, "token_type": TokenTypeEnum.ACCESS_TOKEN.value}
+        token_str = jwt.encode(payload=payload, key=self._secret_key, algorithm=self._algorithm)
+        return TokenDataDTO(token_str=token_str, expires_at=expires_at)
+
+    def create_email_token(self, email: str) -> TokenDataDTO:
+        expires_at = datetime.now(timezone.utc) + self._email_token_lifetime
+        payload = {"sub": email, "exp": expires_at, "token_type": TokenTypeEnum.EMAIL_CONFIRMATION_TOKEN.value}
+        token_str = jwt.encode(payload=payload, key=self._secret_key, algorithm=self._algorithm)
+        return TokenDataDTO(token_str=token_str, expires_at=expires_at)
+
+    def verify_token(self, token: str, expected_type: TokenTypeEnum) -> dict:
+        try:
+            payload = jwt.decode(token, self._secret_key, algorithms=[self._algorithm])
+
+            token_type = payload.get("token_type")
+            if not token_type or token_type != expected_type:
+                raise ValueError("Wrong token type!")
+
+        except jwt.PyJWTError as e:
+            raise ValueError(f"Invalid token ...: {e}")

--- a/src/core/users/infrastructure/user_repository.py
+++ b/src/core/users/infrastructure/user_repository.py
@@ -2,11 +2,12 @@ import uuid
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
 
-from src.core.users.domain.entities import UserAggregate
+from src.core.users.domain.entities import UserAggregate, AuthTokenAggregate
 from src.core.users.domain.interfaces import AbstractRepository
-from src.core.users.infrastructure.mappers import UserORMMapper
-from src.configuration.database.models.users import User
+from src.core.users.infrastructure.mappers import UserMapper, AuthTokenMapper
+from src.configuration.database.models.users import User, AuthToken
 
 
 class UserRepository(AbstractRepository):
@@ -19,11 +20,49 @@ class UserRepository(AbstractRepository):
         return result.scalar_one_or_none()
 
     async def save(self, user: UserAggregate) -> None:
-        user_orm = UserORMMapper.to_orm(user)
+        user_orm = UserMapper.to_orm(user)
         self.session.add(user_orm)
         await self.session.commit()
 
-    async def get_by_email(self, email: str) -> "":
-        statement = select(User).where(User.email == email)
+    async def get_by_email(self, email: str) -> UserAggregate:
+        statement = (
+            select(User)
+            .options(
+                joinedload(User.individual_profile),
+                joinedload(User.business_profile),
+                joinedload(User.auth)
+            ).where(User.email == email)
+        )
+
         result = await self.session.execute(statement)
-        return result.scalar_one_or_none()
+        user_model = result.scalar_one_or_none()
+
+        if user_model is None:
+            return None
+
+        return UserMapper.to_domain(user_model)
+
+
+class AuthTokenRepository:
+    def __init__(self, session: AsyncSession):
+        self._session = session
+
+    async def find_by_value(self, token_value: str) -> AuthTokenAggregate:
+        statement = select(AuthToken).where(AuthToken.token_value == token_value)
+        query_result = await self._session.execute(statement)
+        return AuthTokenMapper.to_domain(query_result.scalar_one_or_none())
+
+    async def find_by_user_id(self, user_id: uuid.UUID) -> list[AuthTokenAggregate]:
+        statement = select(AuthToken).where(AuthToken.user_id == user_id)
+        query_result = await self._session.execute(statement)
+        return AuthTokenMapper.to_domain(query_result.scalars().all())
+
+    async def find_by_token_id(self, token_id: uuid.UUID) -> AuthTokenAggregate:
+        statement = select(AuthToken).where(AuthToken.id == token_id)
+        query_result = await self._session.execute(statement)
+        return AuthTokenMapper.to_domain(query_result.scalar_one_or_none())
+
+    async def save(self, token_aggregate: AuthTokenAggregate) -> None:
+        token_model = AuthTokenMapper.to_orm(token_aggregate)
+        self._session.add(token_model)
+        await self._session.commit()


### PR DESCRIPTION
- Added LoginUserUseCase to handle the complete authentication flow.
- Implemented PyJWTTokenService with methods for creating access and refresh tokens, configured via the DI container.
- Added AuthTokenRepository and AuthTokenMapper for persisting refresh tokens.
- Exposed the `POST /api/v1/auth/login` endpoint for user sign-in.
- Broke down the complex `execute` method into smaller, single-purpose private methods (`_get_validated_user`, `_create_token_pair`, etc.).
- Improved readability and adherence to the Single Responsibility Principle at the method level.

Closes: #5